### PR TITLE
Return error when a failure occurs instead of fatal logging

### DIFF
--- a/scholar_test.go
+++ b/scholar_test.go
@@ -17,8 +17,8 @@ func TestScholarQuerier(t *testing.T) {
 func TestProfileQuerier(t *testing.T) {
 	sch := New("profiles.json", "articles.json")
 	articles, err := sch.QueryProfile("SbUmSEAAAAAJ", 1)
-	assert.NotEmpty(t, articles)
 	assert.Nil(t, err)
+	assert.NotEmpty(t, articles)
 
 	for _, article := range articles {
 		fmt.Println(article)

--- a/scholar_test.go
+++ b/scholar_test.go
@@ -16,8 +16,9 @@ func TestScholarQuerier(t *testing.T) {
 
 func TestProfileQuerier(t *testing.T) {
 	sch := New("profiles.json", "articles.json")
-	articles := sch.QueryProfile("SbUmSEAAAAAJ", 1)
+	articles, err := sch.QueryProfile("SbUmSEAAAAAJ", 1)
 	assert.NotEmpty(t, articles)
+	assert.Nil(t, err)
 
 	for _, article := range articles {
 		fmt.Println(article)


### PR DESCRIPTION
In another project, when we fail to get the profile or an article, the fatal logging was causing web pages to 502.

This should hopefully make it more recoverable